### PR TITLE
full matching to response

### DIFF
--- a/R/CNode.R
+++ b/R/CNode.R
@@ -112,7 +112,7 @@ setMethod("CNode", signature("character"), function(x) {
   # Get the node listing for just this CN using just the baseURL, as we don't know the API version number
   # yet that is needed to construct the service URL.
   response <- GET(CN_URI)   
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     stop(sprintf("Error accessing %s: %s\n", CN_URI, getErrorDescription(response)))
   }
   # Search for the 'node' element. Have to search for local name in xpath, as DataONE v1 and v2 use different namespaces
@@ -225,7 +225,7 @@ setMethod("getFormat", signature("CNode"), function(x, formatId) {
   url <- paste(x@endpoint,"formats", URLencode(formatId, reserved=T), sep="/")
   response <- GET(url, user_agent(get_user_agent()))
   
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     return(NULL)
   }
   
@@ -295,7 +295,7 @@ setMethod("listNodes", signature("CNode"), function(x, url=as.character(NA), ...
     }
     # Don't need authorized access, so call GET directly vs auth_get
     response <- GET(url)
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         return(NULL)
     }
     
@@ -346,7 +346,7 @@ setMethod("reserveIdentifier", signature("CNode"), function(x, id) {
   response <- auth_post(url, encode="multipart", body=list(pid=id), node=x)
   # Note: the DataONE reserveIdentifier service uses the subject from the client certificate
   # as the subject to reserve the identifier for.
-  if(response$status != "200") {
+  if(response$status_code != "200") {
       warning(sprintf("Error reserving identifier %s: %s\n", id, getErrorDescription(response)))
     return(NULL)
   } else {
@@ -414,7 +414,7 @@ setMethod("hasReservation", signature("CNode"), function(x, pid, subject=as.char
   #                      to access it
   #     404              A reservation for the pid does not exist
   # 
-  if(response$status != "200") {
+  if(response$status_code != "200") {
       warning(sprintf("Error checking reservation for pid=%ssubject=%s: %s\n", 
                  pid, subject, getErrorDescription(response)))
     return(FALSE)
@@ -449,7 +449,7 @@ setMethod("setObsoletedBy", signature("CNode", "character"), function(x, pid, ob
   url <- paste(x@endpoint, "obsoletedBy", URLencode(pid, reserved=TRUE), sep="/")
   body=list(obsoletedByPid=URLencode(obsoletedByPid), serialVersion=serialVersion)
   response <- auth_put(url=url, body=body, node=x)
-  if(response$status != "200") {
+  if(response$status_code != "200") {
       warning(sprintf("Error obsoleting %s: %s\n", pid, getErrorDescription(response)))
     return(FALSE)
   } else {
@@ -462,7 +462,7 @@ setMethod("getObject", signature("CNode"), function(x, pid) {
     url <- paste(x@endpoint, "object", URLencode(pid, reserved=T), sep="/")
     response <- auth_get(url, node=x)
     
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         warning(sprintf("Error getting pid: %s\n", getErrorDescription(response)))
         return(NULL)
     }
@@ -491,7 +491,7 @@ setMethod("getSystemMetadata", signature("CNode"), function(x, pid) {
     url <- paste(x@endpoint, "meta", URLencode(pid, reserved=T), sep="/")
     response <- auth_get(url, node=x)
     
-    if(response$status != "200") {
+    if(response$status_code != "200") {
       warning(sprintf("Error getting SystemMetadata: %s\n", getErrorDescription(response)))
         return(NULL)
     }
@@ -639,7 +639,7 @@ setGeneric("echoCredentials", function(x, ...) {
 setMethod("echoCredentials", signature(x = "CNode"), function(x) {
   url <- sprintf("%s/diag/subject", x@endpoint)
   response <- auth_get(url, node=x)
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     warning(sprintf("Error checking credentails %s", getErrorDescription(response)))
     return(as.character(NA))
   }

--- a/R/D1Node.R
+++ b/R/D1Node.R
@@ -177,7 +177,7 @@ setGeneric("archive", function(x, ...) {
 setMethod("archive", signature("D1Node"), function(x, pid) {
     url <- paste(x@endpoint, "archive", URLencode(pid, reserved=TRUE), sep="/")
     response <- auth_put(url, node=x)
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         warning(sprintf("Error archiving %s\n", pid))
         return(NULL)
     } else {
@@ -265,7 +265,7 @@ setMethod("getQueryEngineDescription", signature("D1Node"), function(x, queryEng
   url <- paste(x@endpoint, "query", queryEngineName, sep="/")
   # Send the request
   response<-GET(url)
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     warning(sprintf("Error getting query engine description %s\n", getErrorDescription(response)))
     return(list())
   }
@@ -360,7 +360,7 @@ setMethod("describeObject", signature("D1Node"), function(x, pid) {
   stopifnot(is.character(pid))
   url <- file.path(x@endpoint, "object", URLencode(pid, reserved=T))
   response <- auth_get(url, node=x)
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     d1_errors(response)
   } else { 
     return(unclass(response$headers))
@@ -576,7 +576,7 @@ setMethod("ping", signature("D1Node"), function(x) {
   # Send the request
   response<-GET(url)
 
-  if (response$status == 200) {
+  if (response$status_code == 200) {
     return(TRUE)
   } else {
     return(FALSE)
@@ -812,7 +812,7 @@ setMethod("query", signature("D1Node"), function(x, solrQuery=as.character(NA), 
   
   if(is.null(response)) return(NULL)
   
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     message(sprintf("Error accessing %s: %s\n", queryUrl, getErrorDescription(response)))
     return(NULL)
   }
@@ -986,9 +986,9 @@ setMethod("isAuthorized", signature("D1Node"), function(x, id, action) {
     response <- auth_get(url, node=x)
     # Status = 200 means that the action is authorized for the id.
     # Status = 401 means that the subject is not authorized for the action, not an error.
-    if(response$status == "401") {
+    if(response$status_code == "401") {
         return(FALSE)
-    } else if (response$status != "200") {
+    } else if (response$status_code != "200") {
         warning(sprintf("Error checking authorized for action \"%s\" on id:\" %s\": %s", action, id, getErrorDescription(response)))
         return(FALSE)
     } else {

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -205,7 +205,7 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
   response <- GET(url, user_agent(get_user_agent()))
   # Use charset 'utf-8' if not specified in response headers
   charset <- "utf-8"
-  if(response$status != "200") {
+  if(response$status_code != "200") {
     stop(sprintf("Error accessing %s: %s\n", x@endpoint, getErrorDescription(response)))
   } else {
     if("content-type" %in% names(response$headers)) {
@@ -243,7 +243,7 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     
     response <- auth_get(url, node=x)
     
-    if (response$status != "200") {
+    if (response$status_code != "200") {
         stop(sprintf("get() error: %s\n", getErrorDescription(response)))
     }
     return(content(response, as = "raw"))
@@ -259,7 +259,7 @@ setMethod("getSystemMetadata", signature("MNode"), function(x, pid) {
     
     # Use charset 'utf-8' if not specified in response headers
     charset <- "utf-8"
-    if(response$status != "200") {
+    if(response$status_code != "200") {
       warning(sprintf("Error getting SystemMetadata: %s\n", getErrorDescription(response)))
         return(NULL)
     } else {
@@ -402,7 +402,7 @@ setMethod("createObject", signature("MNode"), function(x, pid, file=as.character
     
     # Use charset 'utf-8' if not specified in response headers
     charset <- "utf-8"
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         #d1_errors(response)
         stop(sprintf("Error creating %s: %s\n", pid, getErrorDescription(response)))
     } else {
@@ -489,7 +489,7 @@ setMethod("updateObject", signature("MNode"), function(x, pid, file=as.character
                 body=list(pid=pid, object=upload_file(file), 
                 newPid=newpid, sysmeta=upload_file(sm_file, type='text/xml')), node=x)
     
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         #d1_errors(response)
         stop(sprintf("Error updating %s: %s\n", pid, getErrorDescription(response)))
     } else {
@@ -561,7 +561,7 @@ setMethod("updateSystemMetadata", signature("MNode"), function(x, pid, sysmeta) 
     sm_file <- tempfile()
     writeLines(sysmetaxml, sm_file)
     response <- auth_put(url, encode="multipart", body=list(pid=pid, sysmeta=upload_file(sm_file, type='text/xml')), node=x)
-    if(response$status != "200") {
+    if(response$status_code != "200") {
       warning(sprintf("Error updating %s: %s\n", pid, getErrorDescription(response)))
       return(FALSE)
     } else {
@@ -613,7 +613,7 @@ setMethod("generateIdentifier", signature("MNode"), function(x, scheme="UUID", f
     
     response <- auth_post(url=url,  encode="multipart", body=body, node=x)
     charset <- "utf-8"
-    if(response$status != "200") {
+    if(response$status_code != "200") {
         stop(sprintf("Error generating ID of type %s: %s\n", scheme, getErrorDescription(response)))
     } else {
       if("content-type" %in% names(response$headers)) {
@@ -730,7 +730,7 @@ setMethod("getPackage", signature("MNode"), function(x, identifier, format="appl
     url <- sprintf("%s/packages/%s/%s", x@endpoint, URLencode(format, reserved=T), resmapId)
     response <- auth_get(url, node=x)
     
-    if (response$status == "200") {
+    if (response$status_code == "200") {
         packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
         packageBin <- content(response, as="raw")
         writeBin(packageBin, packageFile)


### PR DESCRIPTION
I have `options(warnPartialMatchAttr = TRUE)` set following the recommendations at:
 https://kevinushey.github.io/blog/2015/02/02/rprofile-essentials/

This PR fixes warnings because of partial matching of `response$status` to `response$status_code`.