### PR TITLE
Allow download of object if specify path in getObject

### DIFF
--- a/R/MNode.R
+++ b/R/MNode.R
@@ -234,12 +234,9 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     url <- paste(x@endpoint, "object", URLencode(pid, reserved=T), sep="/")
     
     # Check if the requested pid has been obsoleted by a newer version
-    # and print a warning
-    if (!is.null(path)) {
-      check = as.logical(TRUE)
-    }
-    
-    if (check) {
+    # and print a warning.
+    # Will run if a path is given to gather sysmeta.
+    if (check || !is.null(path)) {
         sysmeta <- getSystemMetadata(x, pid)
         if (!is.na(sysmeta@obsoletedBy)) {
             message(sprintf('Warning: pid "%s" is obsoleted by pid "%s"', pid, sysmeta@obsoletedBy))

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -251,7 +251,7 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
       
       # Set file path to path/filename 
       filename <- gsub("[^a-zA-Z0-9\\.\\-]", "_", pid)
-      path <- paste0(sub("\\/+$", "", path), "/", filename)
+      path <- file.path(path, filename)
     }
     
     response <- auth_get(url, node=x, path=path)

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -221,7 +221,7 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 })
 
 #' @param check A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.
-#' @param path (optional) Path to a folder to write object to
+#' @param path (optional) Path to a directory to write object to. The filename will be equivalent to the pid. The function will fail if a file with the same name already exists in the directory.
 #' @rdname getObject
 setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL) {
   
@@ -234,9 +234,8 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     url <- paste(x@endpoint, "object", URLencode(pid, reserved=T), sep="/")
     
     # Check if the requested pid has been obsoleted by a newer version
-    # and print a warning.
-    # Will run if a path is given to gather sysmeta.
-    if (check || !is.null(path)) {
+    # and print a warning
+    if (check) {
         sysmeta <- getSystemMetadata(x, pid)
         if (!is.na(sysmeta@obsoletedBy)) {
             message(sprintf('Warning: pid "%s" is obsoleted by pid "%s"', pid, sysmeta@obsoletedBy))
@@ -250,12 +249,8 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
         stop("path is not a valid directory path")
       }
       
-      if (is.na(sysmeta@fileName)){
-        filename <- pid
-      } else {
-        filename <- sysmeta@fileName
-      }
-      path <- paste0(sub("\\/+$", "", path), "/", filename)
+      # Set file path to path/pid. 
+      path <- paste0(sub("\\/+$", "", path), "/", pid)
     }
     
     response <- auth_get(url, node=x, path=path)

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -221,7 +221,7 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 })
 
 #' @param check A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.
-#' @param path (optional) Path to a directory to write object to. The filename will be equivalent to the pid. The function will fail if a file with the same name already exists in the directory.
+#' @param path (optional) Path to a directory to write object to. The filename will be equivalent to the pid with all special characters removed i.e. \code{filename <- gsub("[^a-zA-Z0-9\\\.\\\-]", "_", pid)}. The function will fail if a file with the same name already exists in the directory.
 #' @rdname getObject
 setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL) {
   
@@ -249,8 +249,9 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
         stop("path is not a valid directory path")
       }
       
-      # Set file path to path/pid. 
-      path <- paste0(sub("\\/+$", "", path), "/", pid)
+      # Set file path to path/filename 
+      filename <- gsub("[^a-zA-Z0-9\\.\\-]", "_", pid)
+      path <- paste0(sub("\\/+$", "", path), "/", filename)
     }
     
     response <- auth_get(url, node=x, path=path)

--- a/R/auth_request.R
+++ b/R/auth_request.R
@@ -29,10 +29,16 @@
 #' @param url The URL to be accessed via authenticated GET.
 #' @param nconfig HTTP configuration options as used by curl, defaults to empty list
 #' @param node The D1Node object that the request will be made to.
+#' @param path Path to a file to write object to
 #' @return the response object from the method
 #' @import httr
-auth_get <- function(url, nconfig=config(), node) {
+auth_get <- function(url, nconfig=config(), node, path = NULL) {
   response <- NULL
+  if (is.null(path)) {
+    write_path <- NULL
+  } else {
+    write_path <- httr::write_disk(path, overwrite = TRUE)
+  }
   if (missing(url) || missing(node)) {
       stop("Error: url or node is missing. Please report this error.")
   }
@@ -41,12 +47,12 @@ auth_get <- function(url, nconfig=config(), node) {
     if(getAuthMethod(am, node) == "token") {
       # Authentication will use an authentication token.
       authToken <- getToken(am, node)
-      response <- GET(url, config = nconfig, user_agent(get_user_agent()), add_headers(Authorization = sprintf("Bearer %s", authToken)))
+      response <- GET(url, config = nconfig, user_agent(get_user_agent()), add_headers(Authorization = sprintf("Bearer %s", authToken)), write_path)
     } else {
       # Authentication will use a certificate.
       cert <- getCert(am)
       new_config <- c(nconfig, config(sslcert = cert))
-      response <- GET(url, config = new_config, user_agent(get_user_agent()))
+      response <- GET(url, config = new_config, user_agent(get_user_agent()), write_path)
     }
   } else {
     # Send request as the public user
@@ -78,7 +84,7 @@ auth_get <- function(url, nconfig=config(), node) {
       }
     }
       
-    response <- GET(url, config=nconfig, user_agent(get_user_agent()))   # the anonymous access case
+    response <- GET(url, config=nconfig, user_agent(get_user_agent()), write_path)   # the anonymous access case
   }
   rm(am)
   

--- a/R/auth_request.R
+++ b/R/auth_request.R
@@ -37,7 +37,7 @@ auth_get <- function(url, nconfig=config(), node, path = NULL) {
   if (is.null(path)) {
     write_path <- NULL
   } else {
-    write_path <- httr::write_disk(path, overwrite = TRUE)
+    write_path <- httr::write_disk(path, overwrite = FALSE)
   }
   if (missing(url) || missing(node)) {
       stop("Error: url or node is missing. Please report this error.")

--- a/man/auth_get.Rd
+++ b/man/auth_get.Rd
@@ -4,7 +4,7 @@
 \alias{auth_get}
 \title{GET a resource with authenticated credentials if available.}
 \usage{
-auth_get(url, nconfig = config(), node)
+auth_get(url, nconfig = config(), node, path = NULL)
 }
 \arguments{
 \item{url}{The URL to be accessed via authenticated GET.}
@@ -12,6 +12,8 @@ auth_get(url, nconfig = config(), node)
 \item{nconfig}{HTTP configuration options as used by curl, defaults to empty list}
 
 \item{node}{The D1Node object that the request will be made to.}
+
+\item{path}{Path to a file to write object to}
 }
 \value{
 the response object from the method

--- a/man/getObject.Rd
+++ b/man/getObject.Rd
@@ -11,7 +11,7 @@ getObject(x, ...)
 
 \S4method{getObject}{CNode}(x, pid)
 
-\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE))
+\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), path = NULL)
 }
 \arguments{
 \item{x}{The Node instance from which the pid will be downloaded}
@@ -21,6 +21,8 @@ getObject(x, ...)
 \item{pid}{The identifier of the object to be downloaded}
 
 \item{check}{A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.}
+
+\item{path}{(optional) Path to a folder to write object to}
 }
 \value{
 the bytes of the object

--- a/man/getObject.Rd
+++ b/man/getObject.Rd
@@ -22,7 +22,7 @@ getObject(x, ...)
 
 \item{check}{A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.}
 
-\item{path}{(optional) Path to a folder to write object to}
+\item{path}{(optional) Path to a directory to write object to. The filename will be equivalent to the pid with all special characters removed i.e. \code{filename <- gsub("[^a-zA-Z0-9\\\.\\\-]", "_", pid)}. The function will fail if a file with the same name already exists in the directory.}
 }
 \value{
 the bytes of the object


### PR DESCRIPTION
To facilitate efficient and reliable data management, it would be very helpful if getObject would allow users to download the object to a given folder path. This is critical for files like excel files in which `rawToChar` commands fail in R effectively leaving users without an efficient way of accessing such files directly from a DataONE node.