### PR TITLE
Added destination path & unzip to `getPackage` arguments

### DIFF
--- a/R/MNode.R
+++ b/R/MNode.R
@@ -658,100 +658,100 @@ setGeneric("getPackage", function(x, ...) {
 #' @param format The format to send the package in.
 #' @param dirPath The directory path to save the package to.
 setMethod("getPackage", signature("MNode"), function(x, identifier, format="application/bagit-097", dirPath=NULL) {
-    
-    # The identifier provided could be the package id (resource map), the metadata id or a package member (data, etc)
-    # The solr queries attempt to determine which id was specified and may issue additional queries to get all the
-    # data, for example, the metadata solr record must be retrieved to obtain all the package members.
-    resmapId <- as.character(NA)
-    metadataPid <- as.character(NA)
-    # First find the metadata object for a package. Try to get all required info, but not all record types have all 
-    # these fields filled out.
-    queryParamList <- list(q=sprintf('id:\"%s\"', identifier), fl='isDocumentedBy,resourceMap,documents,formatType')
+  
+  # The identifier provided could be the package id (resource map), the metadata id or a package member (data, etc)
+  # The solr queries attempt to determine which id was specified and may issue additional queries to get all the
+  # data, for example, the metadata solr record must be retrieved to obtain all the package members.
+  resmapId <- as.character(NA)
+  metadataPid <- as.character(NA)
+  # First find the metadata object for a package. Try to get all required info, but not all record types have all 
+  # these fields filled out.
+  queryParamList <- list(q=sprintf('id:\"%s\"', identifier), fl='isDocumentedBy,resourceMap,documents,formatType')
+  result <- query(x, queryParamList, as="list")
+  # Didn't get a result from the CN, query the MN directly. This may happen for several reasons including
+  # a new package hasn't been synced to the CN, the package is in a dev environment where CN sync is off, etc.
+  if(is.null(result) || length(result) == 0) {
+    stop(sprintf("Identifier %s not found on node %s", identifier, x@identifier))
+  } 
+  
+  formatType <- result[[1]]$formatType[[1]]
+  # Check if we have the metadata object, and if not, then get it. If a data object pid was specified, then it is possible that
+  # it can be contained in mulitple packages. For now, just use the first package returned. 
+  # TODO: follow the obsolesence chain up to the most current version.
+  if(formatType == "METADATA") {
+    # We have the metadata object, which contains the list of package members in the 'documents' field
+    resmapId <- result[[1]]$resourceMap
+    metadataPid <- identifier
+    packageMembers <- as.list(result[[1]]$documents)
+  } else if(formatType == "RESOURCE") {
+    resmapId <- identifier
+    # Get the metadata object for this resource map
+    queryParamList <- list(q=sprintf('resourceMap:\"%s\"', identifier), fq='formatType:METADATA', fl='id,documents,formatType')
     result <- query(x, queryParamList, as="list")
-    # Didn't get a result from the CN, query the MN directly. This may happen for several reasons including
-    # a new package hasn't been synced to the CN, the package is in a dev environment where CN sync is off, etc.
-    if(is.null(result) || length(result) == 0) {
-        stop(sprintf("Identifier %s not found on node %s", identifier, x@identifier))
-    } 
-    
-    formatType <- result[[1]]$formatType[[1]]
-    # Check if we have the metadata object, and if not, then get it. If a data object pid was specified, then it is possible that
-    # it can be contained in mulitple packages. For now, just use the first package returned. 
-    # TODO: follow the obsolesence chain up to the most current version.
-    if(formatType == "METADATA") {
-        # We have the metadata object, which contains the list of package members in the 'documents' field
-        resmapId <- result[[1]]$resourceMap
-        metadataPid <- identifier
-        packageMembers <- as.list(result[[1]]$documents)
-    } else if(formatType == "RESOURCE") {
-        resmapId <- identifier
-        # Get the metadata object for this resource map
-        queryParamList <- list(q=sprintf('resourceMap:\"%s\"', identifier), fq='formatType:METADATA', fl='id,documents,formatType')
-        result <- query(x, queryParamList, as="list")
-        if (length(result) == 0) {
-            stop(sprintf("Unable to find metadata object for identifier: %s on node %s", identifier, x@identifier))
-        }
-        metadataPid <- result[[1]]$id
-        packageMembers <- as.list(result[[1]]$documents)
-    } else {
-        # This must be a package member, so get the metadata pid for the package
-        metadataPid <- result[[1]]$isDocumentedBy
-        queryParamList <- list(q=sprintf('id:\"%s\"', metadataPid), fl='documents,formatType,resourceMap')
-        result <- query(x, queryParamList, as="list")
-        if (length(result) == 0) {
-            stop(sprintf("Unable to find metadata object with identifier: %s on node %", identifier, x@identifier))
-        }
-        resmapId <- result[[1]]$resourceMap
-        packageMembers <- as.list(result[[1]]$documents)
+    if (length(result) == 0) {
+      stop(sprintf("Unable to find metadata object for identifier: %s on node %s", identifier, x@identifier))
     }
+    metadataPid <- result[[1]]$id
+    packageMembers <- as.list(result[[1]]$documents)
+  } else {
+    # This must be a package member, so get the metadata pid for the package
+    metadataPid <- result[[1]]$isDocumentedBy
+    queryParamList <- list(q=sprintf('id:\"%s\"', metadataPid), fl='documents,formatType,resourceMap')
+    result <- query(x, queryParamList, as="list")
+    if (length(result) == 0) {
+      stop(sprintf("Unable to find metadata object with identifier: %s on node %", identifier, x@identifier))
+    }
+    resmapId <- result[[1]]$resourceMap
+    packageMembers <- as.list(result[[1]]$documents)
+  }
+  
+  # The Solr index can contain multiple resource maps that refer to our metadata object. There should be only
+  # one current resource map that refers to this metadata, the others may be previous versions of the resmap
+  # that are now obsolete. If multple resource map pids were returned, filter out the obsolete ones.
+  if(length(resmapId) > 1) {
+    quoteSetting <- getOption("useFancyQuotes")
+    options(useFancyQuotes = FALSE)
+    newIds <- dQuote(unlist(resmapId))
+    options(useFancyQuotes = quoteSetting)
     
-    # The Solr index can contain multiple resource maps that refer to our metadata object. There should be only
-    # one current resource map that refers to this metadata, the others may be previous versions of the resmap
-    # that are now obsolete. If multple resource map pids were returned, filter out the obsolete ones.
+    qStr <- sprintf("id:(%s)", paste(newIds, collapse=" OR "))
+    queryParamList <- list(q=qStr, fq="NOT obsoletedBy:* AND archived:false", fl="id")
+    result <- query(x, queryParamList, as="list")
+    resmapId <- unlist(result)
+    if(length(resmapId) == 0) {
+      stop("It appears that all resource maps that reference this package are obsolete or archived.")
+    }
     if(length(resmapId) > 1) {
-        quoteSetting <- getOption("useFancyQuotes")
-        options(useFancyQuotes = FALSE)
-        newIds <- dQuote(unlist(resmapId))
-        options(useFancyQuotes = quoteSetting)
-        
-        qStr <- sprintf("id:(%s)", paste(newIds, collapse=" OR "))
-        queryParamList <- list(q=qStr, fq="NOT obsoletedBy:* AND archived:false", fl="id")
-        result <- query(x, queryParamList, as="list")
-        resmapId <- unlist(result)
-        if(length(resmapId) == 0) {
-            stop("It appears that all resource maps that reference this package are obsolete or archived.")
-        }
-        if(length(resmapId) > 1) {
-            resmapStr <- paste(resmapId, collapse=", ")
-            stop(sprintf("The metadata identifier %s is referenced by more than one current resource map: %s", metadataPid, resmapStr))
-        }
+      resmapStr <- paste(resmapId, collapse=", ")
+      stop(sprintf("The metadata identifier %s is referenced by more than one current resource map: %s", metadataPid, resmapStr))
     }
-    
-    # getPackage was implemented in API v1.2
-    url <- sprintf("%s/packages/%s/%s", x@endpoint, URLencode(format, reserved=T), resmapId)
-    response <- auth_get(url, node=x)
-    
-    if (response$status_code == "200") {
-      if(!is.null(dirPath)){
-        stopifnot(is.character(dirPath))
-        stopifnot(dir.exists(dirPath))
-        
-        fileName <- paste0(gsub("[[:punct:]]", "_", identifier), ".zip")
-        packageFile <- file.path(dirPath, fileName)
-        
-        if(!file.exists(packageFile)){
-          file.create(packageFile)
-        }
-      } else {
-        packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
+  }
+  
+  # getPackage was implemented in API v1.2
+  url <- sprintf("%s/packages/%s/%s", x@endpoint, URLencode(format, reserved=T), resmapId)
+  response <- auth_get(url, node=x)
+  
+  if (response$status_code == "200") {
+    if(!is.null(dirPath)){
+      stopifnot(is.character(dirPath))
+      stopifnot(dir.exists(dirPath))
+      
+      fileName <- paste0(gsub("[[:punct:]]", "_", identifier), ".zip")
+      packageFile <- file.path(dirPath, fileName)
+      
+      if(!file.exists(packageFile)){
+        file.create(packageFile)
       }
-        packageBin <- content(response, as="raw")
-        writeBin(packageBin, packageFile)
-        return(packageFile)
     } else {
-        warning(sprintf("Error calling getPackage: %s\n", getErrorDescription(response)))
-        return(NULL)
+      packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
     }
+    packageBin <- content(response, as="raw")
+    writeBin(packageBin, packageFile)
+    return(packageFile)
+  } else {
+    warning(sprintf("Error calling getPackage: %s\n", getErrorDescription(response)))
+    return(NULL)
+  }
 })
 
 ############# Private functions, internal to this class, not for external callers #################

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -656,7 +656,8 @@ setGeneric("getPackage", function(x, ...) {
 #' @param identifier The identifier of the package to retrieve. The identifier can be for the
 #' resource map, metadata file, data file, or any other package member.
 #' @param format The format to send the package in.
-setMethod("getPackage", signature("MNode"), function(x, identifier, format="application/bagit-097") {
+#' @param dirPath The directory path to save the package to.
+setMethod("getPackage", signature("MNode"), function(x, identifier, format="application/bagit-097", dirPath=NULL) {
     
     # The identifier provided could be the package id (resource map), the metadata id or a package member (data, etc)
     # The solr queries attempt to determine which id was specified and may issue additional queries to get all the
@@ -731,7 +732,19 @@ setMethod("getPackage", signature("MNode"), function(x, identifier, format="appl
     response <- auth_get(url, node=x)
     
     if (response$status_code == "200") {
+      if(!is.null(dirPath)){
+        stopifnot(is.character(dirPath))
+        stopifnot(dir.exists(dirPath))
+        
+        fileName <- paste0(gsub("[[:punct:]]", "_", identifier), ".zip")
+        packageFile <- file.path(dirPath, fileName)
+        
+        if(!file.exists(packageFile)){
+          file.create(packageFile)
+        }
+      } else {
         packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
+      }
         packageBin <- content(response, as="raw")
         writeBin(packageBin, packageFile)
         return(packageFile)


### PR DESCRIPTION
Now if you specify a directory path, the zip file will be saved directly to the path specified (in this case, the current working directory), rather than to a temp folder.

```
cn <- dataone::CNode("PROD")
mn <- dataone::getMNode(cn, "urn:node:ARCTIC")
getPackage(mn, "resource_map_doi:10.18739/A2MQ00", dirPath = ".")
```

If you specify `unzip = TRUE`, the package will be automatically unzipped.
```
getPackage(mn, "resource_map_doi:10.18739/A2MQ00", dirPath = ".", unzip = TRUE)
```

@gothub 