### PR TITLE
Added `as` argument to getObject 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     parsedate,
     uuid,
     base64enc,
-    jsonlite
+    jsonlite,
+    readr
 License: Apache License 2.0
 URL: https://github.com/DataONEorg/rdataone
 BugReports: https://github.com/DataONEorg/rdataone/issues

--- a/R/CNode.R
+++ b/R/CNode.R
@@ -463,7 +463,8 @@ setMethod("getObject", signature("CNode"), function(x, pid, as = "raw") {
     response <- auth_get(url, node=x)
     
     if(response$status_code != "200") {
-        warning(sprintf("Error getting pid: %s\n", getErrorDescription(response)))
+        warning(sprintf("Error getting pid: %s\n", getErrorDescription(response),
+                        "To get a data object, use dataone::resolve() to get its URL and member node."))
         return(NULL)
     }
     

--- a/R/CNode.R
+++ b/R/CNode.R
@@ -458,7 +458,7 @@ setMethod("setObsoletedBy", signature("CNode", "character"), function(x, pid, ob
 })
 
 #' @rdname getObject
-setMethod("getObject", signature("CNode"), function(x, pid) {
+setMethod("getObject", signature("CNode"), function(x, pid, as = "raw") {
     url <- paste(x@endpoint, "object", URLencode(pid, reserved=T), sep="/")
     response <- auth_get(url, node=x)
     
@@ -467,7 +467,7 @@ setMethod("getObject", signature("CNode"), function(x, pid) {
         return(NULL)
     }
     
-    return(content(response, as="raw"))
+    return(content(response, as = as))
 })
 
 #' Get the metadata describing system properties associated with an object on a Coordinating Node.

--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -1071,9 +1071,12 @@ setMethod("uploadDataPackage", signature("D1Client"), function(x, dp, replicate=
             }
             # Remove ':' from filename if on windows (only the pid might have these.)
             if(.Platform$OS.type == "windows") {
-                tf <- tempfile(pattern=sprintf("%s.rdf", gsub(':', '_', newPid)))
+                cleanedPid <- gsub(':', '_', newPid)
+                cleanedPid <- gsub('/', '_', cleanedPid)
+                tf <- sprintf("%s/%s.rdf", tempdir(), cleanedPid)
             } else {
-                tf <- tempfile(pattern=sprintf("%s.rdf", newPid))
+                cleanedPid <- gsub('/', '_', newPid)
+                tf <- sprintf("%s/%s.rdf", tempdir(), cleanedPid)
             }
             status <- serializePackage(dp, file=tf, id=newPid, resolveURI=resolveURI, creator=creator)
             

--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -1238,8 +1238,6 @@ setMethod("uploadDataObject", signature("D1Client"),  function(x, do, replicate=
         # set these values on upload/update.
         do@sysmeta@obsoletes <- as.character(NA)
         do@sysmeta@obsoletedBy <- as.character(NA)
-        do@sysmeta@dateUploaded <- as.character(NA)
-        do@sysmeta@dateSysMetadataModified <- as.character(NA)
         do@sysmeta@archived <- as.logical(NA)
         # Set sysmeta values if passed in and not already set in sysmeta for each data object
         if (!is.na(replicate)) {

--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -1007,11 +1007,14 @@ setMethod("uploadDataPackage", signature("D1Client"), function(x, dp, replicate=
             }
             # Get the pid of the metadata object, if one is available.
             # Remove ':' from filename if on windows (only the pid might have these.)
-            if(.Platform$OS.type == "windows") {
-                tf <- tempfile(pattern=sprintf("%s.rdf", gsub(':', '_', newPid)))
-            } else {
-                tf <- tempfile(pattern=sprintf("%s.rdf", newPid))
-            }
+            # Just use a random id for the filename
+            #if(.Platform$OS.type == "windows") {
+            #    tf <- tempfile(pattern=sprintf("%s.rdf", gsub(':', '_', newPid)))
+            #} else {
+            #    tf <- tempfile(pattern=sprintf("%s.rdf", newPid))
+            #}
+            # Just use a random id for the filename
+            tf <- tempfile(pattern=sprintf("%s.rdf", UUIDgenerate()))
             status <- serializePackage(dp, file=tf, id=newPid, resolveURI=resolveURI, creator=creator)
             # Recreate the old resource map, so that it can be updated with a new pid
             resMapObj <- new("DataObject", id=newPid, format="http://www.openarchives.org/ore/terms", filename=tf)

--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -557,7 +557,11 @@ setMethod("getDataPackage", "D1Client", function(x, identifier, lazyLoad=FALSE, 
   
   # Reset the 'update' status flag on the relations (resourceMap) as this downloaded package
   # has not been updated by the user (after download).
-  dpkg@relations[['updated']] <- FALSE 
+  if(repair) {
+    dpkg@relations[['updated']] <- TRUE
+  } else {
+    dpkg@relations[['updated']] <- FALSE 
+  }
   
   return(dpkg)
 })

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -225,7 +225,6 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 #' @param as The desired type of output: \code{raw}, \code{text}, or \code{parsed}. Passed to \link[httr]{content}.
 #' @rdname getObject
 setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL, as = "raw") {
-
   stopifnot(is.character(pid))
   stopifnot(is.character(as))
     if(!class(check) == "logical") {
@@ -261,7 +260,7 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     if (response$status_code != "200") {
         stop(sprintf("get() error: %s\n", getErrorDescription(response)))
     }
-    
+
     output <- tryCatch({content(response, as = as)},
                        error = function(e){
                          message(gsub("Error: ", "", e),

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -221,8 +221,9 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 })
 
 #' @param check A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.
+#' @param path (optional) Path to a directory to write object to. The filename will be equivalent to the pid with all special characters removed i.e. \code{filename <- gsub("[^a-zA-Z0-9\\\.\\\-]", "_", pid)}. The function will fail if a file with the same name already exists in the directory.
 #' @rdname getObject
-setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE)) {
+setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL) {
   
   stopifnot(is.character(pid))
     if(!class(check) == "logical") {
@@ -241,7 +242,19 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
         }
     }
     
-    response <- auth_get(url, node=x)
+    if(!is.null(path)){
+      stopifnot(is.character(path))
+      
+      if(!dir.exists(path)) {
+        stop("path is not a valid directory path")
+      }
+      
+      # Set file path to path/filename 
+      filename <- gsub("[^a-zA-Z0-9\\.\\-]", "_", pid)
+      path <- file.path(path, filename)
+    }
+    
+    response <- auth_get(url, node=x, path=path)
     
     if (response$status_code != "200") {
         stop(sprintf("get() error: %s\n", getErrorDescription(response)))

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -227,6 +227,7 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL, as = "raw") {
 
   stopifnot(is.character(pid))
+  stopifnot(is.character(as))
     if(!class(check) == "logical") {
       stop("Invalid argument: 'check' must be specified as a logical.")
     }
@@ -260,7 +261,15 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     if (response$status_code != "200") {
         stop(sprintf("get() error: %s\n", getErrorDescription(response)))
     }
-    return(content(response, as = as))
+    
+    output <- tryCatch({content(response, as = as)},
+                       error = function(e){
+                         message(gsub("Error: ", "", e),
+                                 "The raw output has been returned.")
+                         return(content(response, as = "raw"))
+                       })
+    
+    return(output)
 })
 
 #' @import datapack

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -222,9 +222,10 @@ setMethod("getCapabilities", signature("MNode"), function(x) {
 
 #' @param check A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.
 #' @param path (optional) Path to a directory to write object to. The filename will be equivalent to the pid with all special characters removed i.e. \code{filename <- gsub("[^a-zA-Z0-9\\\.\\\-]", "_", pid)}. The function will fail if a file with the same name already exists in the directory.
+#' @param as The desired type of output: \code{raw}, \code{text}, or \code{parsed}. Passed to \link[httr]{content}.
 #' @rdname getObject
-setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL) {
-  
+setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FALSE), path = NULL, as = "raw") {
+
   stopifnot(is.character(pid))
     if(!class(check) == "logical") {
       stop("Invalid argument: 'check' must be specified as a logical.")
@@ -259,7 +260,7 @@ setMethod("getObject", signature("MNode"), function(x, pid, check=as.logical(FAL
     if (response$status_code != "200") {
         stop(sprintf("get() error: %s\n", getErrorDescription(response)))
     }
-    return(content(response, as = "raw"))
+    return(content(response, as = as))
 })
 
 #' @import datapack

--- a/R/MNode.R
+++ b/R/MNode.R
@@ -669,89 +669,116 @@ setGeneric("getPackage", function(x, ...) {
 #' @param identifier The identifier of the package to retrieve. The identifier can be for the
 #' resource map, metadata file, data file, or any other package member.
 #' @param format The format to send the package in.
-setMethod("getPackage", signature("MNode"), function(x, identifier, format="application/bagit-097") {
-    
-    # The identifier provided could be the package id (resource map), the metadata id or a package member (data, etc)
-    # The solr queries attempt to determine which id was specified and may issue additional queries to get all the
-    # data, for example, the metadata solr record must be retrieved to obtain all the package members.
-    resmapId <- as.character(NA)
-    metadataPid <- as.character(NA)
-    # First find the metadata object for a package. Try to get all required info, but not all record types have all 
-    # these fields filled out.
-    queryParamList <- list(q=sprintf('id:\"%s\"', identifier), fl='isDocumentedBy,resourceMap,documents,formatType')
+#' @param dirPath The directory path to save the package to.
+#' @param unzip (logical) If the dirPath is specified, the package can also be unzipped automatically (unzip=TRUE).
+setMethod("getPackage", signature("MNode"), function(x, identifier, format="application/bagit-097", dirPath=NULL, unzip=FALSE) {
+  
+  # The identifier provided could be the package id (resource map), the metadata id or a package member (data, etc)
+  # The solr queries attempt to determine which id was specified and may issue additional queries to get all the
+  # data, for example, the metadata solr record must be retrieved to obtain all the package members.
+  resmapId <- as.character(NA)
+  metadataPid <- as.character(NA)
+  # First find the metadata object for a package. Try to get all required info, but not all record types have all 
+  # these fields filled out.
+  queryParamList <- list(q=sprintf('id:\"%s\"', identifier), fl='isDocumentedBy,resourceMap,documents,formatType')
+  result <- query(x, queryParamList, as="list")
+  # Didn't get a result from the CN, query the MN directly. This may happen for several reasons including
+  # a new package hasn't been synced to the CN, the package is in a dev environment where CN sync is off, etc.
+  if(is.null(result) || length(result) == 0) {
+    stop(sprintf("Identifier %s not found on node %s", identifier, x@identifier))
+  } 
+  
+  formatType <- result[[1]]$formatType[[1]]
+  # Check if we have the metadata object, and if not, then get it. If a data object pid was specified, then it is possible that
+  # it can be contained in mulitple packages. For now, just use the first package returned. 
+  # TODO: follow the obsolesence chain up to the most current version.
+  if(formatType == "METADATA") {
+    # We have the metadata object, which contains the list of package members in the 'documents' field
+    resmapId <- result[[1]]$resourceMap
+    metadataPid <- identifier
+    packageMembers <- as.list(result[[1]]$documents)
+  } else if(formatType == "RESOURCE") {
+    resmapId <- identifier
+    # Get the metadata object for this resource map
+    queryParamList <- list(q=sprintf('resourceMap:\"%s\"', identifier), fq='formatType:METADATA', fl='id,documents,formatType')
     result <- query(x, queryParamList, as="list")
-    # Didn't get a result from the CN, query the MN directly. This may happen for several reasons including
-    # a new package hasn't been synced to the CN, the package is in a dev environment where CN sync is off, etc.
-    if(is.null(result) || length(result) == 0) {
-        stop(sprintf("Identifier %s not found on node %s", identifier, x@identifier))
-    } 
-    
-    formatType <- result[[1]]$formatType[[1]]
-    # Check if we have the metadata object, and if not, then get it. If a data object pid was specified, then it is possible that
-    # it can be contained in mulitple packages. For now, just use the first package returned. 
-    # TODO: follow the obsolesence chain up to the most current version.
-    if(formatType == "METADATA") {
-        # We have the metadata object, which contains the list of package members in the 'documents' field
-        resmapId <- result[[1]]$resourceMap
-        metadataPid <- identifier
-        packageMembers <- as.list(result[[1]]$documents)
-    } else if(formatType == "RESOURCE") {
-        resmapId <- identifier
-        # Get the metadata object for this resource map
-        queryParamList <- list(q=sprintf('resourceMap:\"%s\"', identifier), fq='formatType:METADATA', fl='id,documents,formatType')
-        result <- query(x, queryParamList, as="list")
-        if (length(result) == 0) {
-            stop(sprintf("Unable to find metadata object for identifier: %s on node %s", identifier, x@identifier))
-        }
-        metadataPid <- result[[1]]$id
-        packageMembers <- as.list(result[[1]]$documents)
-    } else {
-        # This must be a package member, so get the metadata pid for the package
-        metadataPid <- result[[1]]$isDocumentedBy
-        queryParamList <- list(q=sprintf('id:\"%s\"', metadataPid), fl='documents,formatType,resourceMap')
-        result <- query(x, queryParamList, as="list")
-        if (length(result) == 0) {
-            stop(sprintf("Unable to find metadata object with identifier: %s on node %", identifier, x@identifier))
-        }
-        resmapId <- result[[1]]$resourceMap
-        packageMembers <- as.list(result[[1]]$documents)
+    if (length(result) == 0) {
+      stop(sprintf("Unable to find metadata object for identifier: %s on node %s", identifier, x@identifier))
     }
+    metadataPid <- result[[1]]$id
+    packageMembers <- as.list(result[[1]]$documents)
+  } else {
+    # This must be a package member, so get the metadata pid for the package
+    metadataPid <- result[[1]]$isDocumentedBy
+    queryParamList <- list(q=sprintf('id:\"%s\"', metadataPid), fl='documents,formatType,resourceMap')
+    result <- query(x, queryParamList, as="list")
+    if (length(result) == 0) {
+      stop(sprintf("Unable to find metadata object with identifier: %s on node %", identifier, x@identifier))
+    }
+    resmapId <- result[[1]]$resourceMap
+    packageMembers <- as.list(result[[1]]$documents)
+  }
+  
+  # The Solr index can contain multiple resource maps that refer to our metadata object. There should be only
+  # one current resource map that refers to this metadata, the others may be previous versions of the resmap
+  # that are now obsolete. If multple resource map pids were returned, filter out the obsolete ones.
+  if(length(resmapId) > 1) {
+    quoteSetting <- getOption("useFancyQuotes")
+    options(useFancyQuotes = FALSE)
+    newIds <- dQuote(unlist(resmapId))
+    options(useFancyQuotes = quoteSetting)
     
-    # The Solr index can contain multiple resource maps that refer to our metadata object. There should be only
-    # one current resource map that refers to this metadata, the others may be previous versions of the resmap
-    # that are now obsolete. If multple resource map pids were returned, filter out the obsolete ones.
+    qStr <- sprintf("id:(%s)", paste(newIds, collapse=" OR "))
+    queryParamList <- list(q=qStr, fq="NOT obsoletedBy:* AND archived:false", fl="id")
+    result <- query(x, queryParamList, as="list")
+    resmapId <- unlist(result)
+    if(length(resmapId) == 0) {
+      stop("It appears that all resource maps that reference this package are obsolete or archived.")
+    }
     if(length(resmapId) > 1) {
-        quoteSetting <- getOption("useFancyQuotes")
-        options(useFancyQuotes = FALSE)
-        newIds <- dQuote(unlist(resmapId))
-        options(useFancyQuotes = quoteSetting)
-        
-        qStr <- sprintf("id:(%s)", paste(newIds, collapse=" OR "))
-        queryParamList <- list(q=qStr, fq="NOT obsoletedBy:* AND archived:false", fl="id")
-        result <- query(x, queryParamList, as="list")
-        resmapId <- unlist(result)
-        if(length(resmapId) == 0) {
-            stop("It appears that all resource maps that reference this package are obsolete or archived.")
-        }
-        if(length(resmapId) > 1) {
-            resmapStr <- paste(resmapId, collapse=", ")
-            stop(sprintf("The metadata identifier %s is referenced by more than one current resource map: %s", metadataPid, resmapStr))
-        }
+      resmapStr <- paste(resmapId, collapse=", ")
+      stop(sprintf("The metadata identifier %s is referenced by more than one current resource map: %s", metadataPid, resmapStr))
     }
-    
-    # getPackage was implemented in API v1.2
-    url <- sprintf("%s/packages/%s/%s", x@endpoint, URLencode(format, reserved=T), resmapId)
-    response <- auth_get(url, node=x)
-    
-    if (response$status_code == "200") {
-        packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
-        packageBin <- content(response, as="raw")
-        writeBin(packageBin, packageFile)
+  }
+  
+  # getPackage was implemented in API v1.2
+  url <- sprintf("%s/packages/%s/%s", x@endpoint, URLencode(format, reserved=T), resmapId)
+  response <- auth_get(url, node=x)
+  
+  if (response$status_code == "200") {
+    if(!is.null(dirPath)){
+      stopifnot(is.character(dirPath))
+      stopifnot(dir.exists(dirPath))
+      
+      fileName <- paste0(gsub("[[:punct:]]", "_", identifier), ".zip")
+      packageFile <- file.path(dirPath, fileName)
+      
+      if(!file.exists(packageFile)){
+        file.create(packageFile)
+      }
+      
+      packageBin <- content(response, as="raw")
+      writeBin(packageBin, packageFile)
+      
+      if(unzip == TRUE){
+        unzip(packageFile, exdir = dirPath)
+        file.remove(packageFile) #remove zip
+        return(gsub(".zip$", "", packageFile)) #unzipped directory path
+      } else {
         return(packageFile)
+      }
+      
     } else {
-        warning(sprintf("Error calling getPackage: %s\n", getErrorDescription(response)))
-        return(NULL)
+      packageFile <- tempfile(pattern=sprintf("%s-", UUIDgenerate()), fileext=".zip")
+      packageBin <- content(response, as="raw")
+      writeBin(packageBin, packageFile)
+      return(packageFile)
     }
+
+  } else {
+    warning(sprintf("Error calling getPackage: %s\n", getErrorDescription(response)))
+    return(NULL)
+  }
 })
 
 ############# Private functions, internal to this class, not for external callers #################

--- a/R/auth_request.R
+++ b/R/auth_request.R
@@ -29,10 +29,16 @@
 #' @param url The URL to be accessed via authenticated GET.
 #' @param nconfig HTTP configuration options as used by curl, defaults to empty list
 #' @param node The D1Node object that the request will be made to.
+#' @param path Path to a file to write object to
 #' @return the response object from the method
 #' @import httr
-auth_get <- function(url, nconfig=config(), node) {
+auth_get <- function(url, nconfig=config(), node, path = NULL) {
   response <- NULL
+  if (is.null(path)) {
+    write_path <- NULL
+  } else {
+    write_path <- httr::write_disk(path, overwrite = FALSE)
+  }
   if (missing(url) || missing(node)) {
       stop("Error: url or node is missing. Please report this error.")
   }
@@ -41,12 +47,12 @@ auth_get <- function(url, nconfig=config(), node) {
     if(getAuthMethod(am, node) == "token") {
       # Authentication will use an authentication token.
       authToken <- getToken(am, node)
-      response <- GET(url, config = nconfig, user_agent(get_user_agent()), add_headers(Authorization = sprintf("Bearer %s", authToken)))
+      response <- GET(url, config = nconfig, user_agent(get_user_agent()), add_headers(Authorization = sprintf("Bearer %s", authToken)), write_path)
     } else {
       # Authentication will use a certificate.
       cert <- getCert(am)
       new_config <- c(nconfig, config(sslcert = cert))
-      response <- GET(url, config = new_config, user_agent(get_user_agent()))
+      response <- GET(url, config = new_config, user_agent(get_user_agent()), write_path)
     }
   } else {
     # Send request as the public user
@@ -78,7 +84,7 @@ auth_get <- function(url, nconfig=config(), node) {
       }
     }
       
-    response <- GET(url, config=nconfig, user_agent(get_user_agent()))   # the anonymous access case
+    response <- GET(url, config=nconfig, user_agent(get_user_agent()), write_path)   # the anonymous access case
   }
   rm(am)
   

--- a/man/auth_get.Rd
+++ b/man/auth_get.Rd
@@ -4,7 +4,7 @@
 \alias{auth_get}
 \title{GET a resource with authenticated credentials if available.}
 \usage{
-auth_get(url, nconfig = config(), node)
+auth_get(url, nconfig = config(), node, path = NULL)
 }
 \arguments{
 \item{url}{The URL to be accessed via authenticated GET.}
@@ -12,6 +12,8 @@ auth_get(url, nconfig = config(), node)
 \item{nconfig}{HTTP configuration options as used by curl, defaults to empty list}
 
 \item{node}{The D1Node object that the request will be made to.}
+
+\item{path}{Path to a file to write object to}
 }
 \value{
 the response object from the method

--- a/man/getObject.Rd
+++ b/man/getObject.Rd
@@ -11,11 +11,8 @@ getObject(x, ...)
 
 \S4method{getObject}{CNode}(x, pid, as = "raw")
 
-<<<<<<< 9947be00e9eb310d1d3d65e1dcc6b0e174aed4b2
-\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), path = NULL)
-=======
-\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), as = "raw")
->>>>>>> Added `as` argument to getObject to allow users to specify what to pass to httr::content.
+\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), path = NULL,
+  as = "raw")
 }
 \arguments{
 \item{x}{The Node instance from which the pid will be downloaded}

--- a/man/getObject.Rd
+++ b/man/getObject.Rd
@@ -9,9 +9,13 @@
 \usage{
 getObject(x, ...)
 
-\S4method{getObject}{CNode}(x, pid)
+\S4method{getObject}{CNode}(x, pid, as = "raw")
 
+<<<<<<< 9947be00e9eb310d1d3d65e1dcc6b0e174aed4b2
 \S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), path = NULL)
+=======
+\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), as = "raw")
+>>>>>>> Added `as` argument to getObject to allow users to specify what to pass to httr::content.
 }
 \arguments{
 \item{x}{The Node instance from which the pid will be downloaded}
@@ -19,6 +23,8 @@ getObject(x, ...)
 \item{...}{(Not yet used).}
 
 \item{pid}{The identifier of the object to be downloaded}
+
+\item{as}{The desired type of output: \code{raw}, \code{text}, or \code{parsed}. Passed to \link[httr]{content}.}
 
 \item{check}{A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.}
 

--- a/man/getObject.Rd
+++ b/man/getObject.Rd
@@ -11,7 +11,7 @@ getObject(x, ...)
 
 \S4method{getObject}{CNode}(x, pid)
 
-\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE))
+\S4method{getObject}{MNode}(x, pid, check = as.logical(FALSE), path = NULL)
 }
 \arguments{
 \item{x}{The Node instance from which the pid will be downloaded}
@@ -21,6 +21,8 @@ getObject(x, ...)
 \item{pid}{The identifier of the object to be downloaded}
 
 \item{check}{A logical value, if TRUE check if this object has been obsoleted by another object in DataONE.}
+
+\item{path}{(optional) Path to a directory to write object to. The filename will be equivalent to the pid with all special characters removed i.e. \code{filename <- gsub("[^a-zA-Z0-9\\\.\\\-]", "_", pid)}. The function will fail if a file with the same name already exists in the directory.}
 }
 \value{
 the bytes of the object

--- a/man/getPackage.Rd
+++ b/man/getPackage.Rd
@@ -8,7 +8,8 @@
 \usage{
 getPackage(x, ...)
 
-\S4method{getPackage}{MNode}(x, identifier, format = "application/bagit-097")
+\S4method{getPackage}{MNode}(x, identifier, format = "application/bagit-097",
+  dirPath = NULL, unzip = FALSE)
 }
 \arguments{
 \item{x}{A MNode instance representing a DataONE Member Node repository.}
@@ -19,6 +20,10 @@ getPackage(x, ...)
 resource map, metadata file, data file, or any other package member.}
 
 \item{format}{The format to send the package in.}
+
+\item{dirPath}{The directory path to save the package to.}
+
+\item{unzip}{(logical) If the dirPath is specified, the package can also be unzipped automatically (unzip=TRUE).}
 }
 \value{
 The location of the package file downloaded from the member node.

--- a/tests/testthat/test.MNode.R
+++ b/tests/testthat/test.MNode.R
@@ -42,6 +42,17 @@ test_that("MNode getObject(), getChecksum()", {
     chksum <- getChecksum(mn, pid)
     expect_that(chksum, is_a("character"))
     expect_false(is.null(chksum))
+    
+    cn <- CNode("PROD")
+    mn <- getMNode(cn, "urn:node:ARCTIC")
+    pid <- "urn:uuid:6ab57f10-f45a-42b2-9422-20aa75cadce5" #cdf file
+    expect_equal(getObject(mn, pid, as = "parsed"),
+                 getObject(mn, pid)) #raw
+    expect_message(getObject(mn, pid, as = "parsed"))
+    
+    pid <- "urn:uuid:9e123f84-ce0d-4094-b898-c9e73680eafa" #csv
+    expect_is(getObject(mn, pid, as = "parsed"),
+              "data.frame")
 })
 test_that("MNode getSystemMetadata()", {
     library(dataone)

--- a/tests/testthat/test.MNode.R
+++ b/tests/testthat/test.MNode.R
@@ -358,6 +358,12 @@ test_that("MNode getPackage() works", {
   suppressWarnings(bagitFile <- getPackage(mnKNB, id=resMapPid))
   expect_true(!is.null(bagitFile))
   expect_true(file.exists(bagitFile))
+  
+  td <- tempdir()
+  suppressWarnings(bagitFile <- getPackage(mnKNB, id=resMapPid, dirPath=td))
+  expect_true(!is.null(bagitFile))
+  expect_true(file.exists(bagitFile))
+  
   # Now check error handling
   # Can't be a valid pid because we just created the unique string.
   #notApid <- sprintf("urn:uuid:%s", UUIDgenerate())


### PR DESCRIPTION
This to allows users to specify what to pass to `httr::content`.

Now to get a csv directly into RStudio, you can do this:

```
cn <- dataone::CNode("PROD")
mn <- dataone::getMNode(cn, "urn:node:ARCTIC")
x <- getObject(mn, "urn:uuid:bf33c6ba-16e6-40de-8f87-1b78ecefbae8", as = "parsed")
``` 
@gothub 