### PR TITLE
upgrade the ubuntu distribution used on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: r
 cache: packages
 warnings_are_errors: true


### PR DESCRIPTION
this prevents travis from failing because of the gnutls handshake error ("unexpected TLS packet")

This issue cropped up recently in all of our Travis builds. The error in this package looks like:

```
── 1. Error: AuthenticationManager isAuthValid() for v2 node works (@test.Authen
gnutls_handshake() failed: An unexpected TLS packet was received.
Backtrace:
 1. dataone::CNode("STAGING")
 2. dataone::CNode("STAGING")
 3. dataone:::.local(x, ...)
 4. httr::GET(CN_URI)
 5. httr:::request_perform(req, hu$handle$handle)
 7. httr:::request_fetch.write_memory(req$output, req$url, handle)
 8. curl::curl_fetch_memory(url, handle = handle)
```

I'm not totally sure what is actually causing the error, since we seem to not have any issues on a variety of platforms when running this locally. All of the builds started failing a few months ago, so my guess is that something may have changed in the underlying libraries. In any case, upgrading the ubuntu distribution that Travis uses solves the build problem, though as @mbjones pointed out on slack, this might merit further investigation since we do see it in the wild sometimes. I recall @amoeba and maybe @datadavev talking about it a while back when I brought up this error at the request of Rachael Blake - but of course I have no record or memory of the conversation.