### PR TITLE
fix bug in updateObject and add test

### DIFF
--- a/R/MNode.R
+++ b/R/MNode.R
@@ -493,7 +493,7 @@ setMethod("updateObject", signature("MNode"), function(x, pid, file=as.character
         stop("Both 'file' and 'dataobj' arguments have been specified")
       }
       file <- tempfile()
-      writeBin(file, dataobj)
+      writeBin(dataobj, file)
     }
     response <- auth_put(url, encode="multipart", 
                 body=list(pid=pid, object=upload_file(file), 

--- a/tests/testthat/test.MNode.R
+++ b/tests/testthat/test.MNode.R
@@ -449,7 +449,7 @@ test_that("MNode updateObject() using dataobj argument", {
         
         # Update the object with a new version
         updateid <- generateIdentifier(mnTest, "UUID")
-        d1test <- D1Client(cn, mnTest)
+        d1test <- D1Client(cnStaging2, mnTest)
         dataObject <- getDataObject(d1test, createdId)
         dataObject@sysmeta@identifier <- updateid
         


### PR DESCRIPTION
This allows the `dataobj` argument to be used instead of a file path when updating an object.
