### PR TITLE
add the limit argument to `getDataObject` for resource maps

### DIFF
--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -611,7 +611,7 @@ setMethod("getDataPackage", "D1Client", function(x, identifier, lazyLoad=FALSE, 
   # Download the resource map, parse it and load the relationships into the DataPackage
   # Currently we only use the first resource map
   if(!quiet) cat(sprintf("Getting resource map with id: %s\n", dpkg@resmapId))
-  resMapObj <- getDataObject(x, identifier=resmapId, lazyLoad=FALSE, checksumAlgorithm=checksumAlgorithm)
+  resMapObj <- getDataObject(x, identifier=resmapId, lazyLoad=FALSE, limit=limit, checksumAlgorithm=checksumAlgorithm)
   # The resource map is not a 'member' of the package, but the sysmeta for it must be retained so that 
   # the state and 'history' of the package can be inspected, so save the resmap sysmeta to the corresponding
   # DataPackage R slot. An example case for inspecting the sysmeta is to determine if the package was newly


### PR DESCRIPTION
When trying to get larger data packages (hundreds to thousand objects) I was getting this error:
```
library(dataone)
d1c <- D1Client("PROD", "urn:node:ARCTIC")
packageId <- "resource_map_urn:uuid:609466e6-28f8-447c-acc7-2de5c01dee0b"
dp <- getDataPackage(d1c, identifier=packageId, lazyLoad=TRUE, quiet=FALSE, limit = "1TB")

#Error in rawToChar(resMapBytes) : argument 'x' must be a raw vector
#In addition: There were 50 or more warnings (use warnings() to see the first 50)
```

We were limited by the 1MB default in `getDataObject` as this argument was not specified for the resource map in `getDataPackage`. The limit argument was added to be consistent.

This bug needs to be fixed in order for Dataone users to edit large data packages