### PR TITLE
if public = TRUE, set public access on data objects AND indicate sysm…

### DIFF
--- a/R/D1Client.R
+++ b/R/D1Client.R
@@ -1013,7 +1013,8 @@ setMethod("uploadDataPackage", signature("D1Client"), function(x, dp, replicate=
         do <- getMember(dp, doId)
         submitter <- do@sysmeta@submitter
         if (public) {
-            do <- setPublicAccess(do)
+             do <- setPublicAccess(do)
+             do@updated[['sysmeta']] <- TRUE
         }
         
         if(!is.na(do@filename)) {


### PR DESCRIPTION
…eta is updated for those objects

this ensures that updateDataObject picks up on the change down the line. addresses issue #285

I've done some testing locally but haven't written a formal test yet